### PR TITLE
removed environment port option

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -2,7 +2,7 @@ const express = require('express');
 const app = module.exports = exports = express();
 const mongoose = require('mongoose');
 const bodyParser = require('body-parser');
-var port = process.env.PORT || 3000;
+var port = 3000;
 
 mongoose.connect(process.env.MONGODB_URI || 'mongodb://localhost/db_celeb');
 app.listen(port, () => console.log('server up on port:' + port));
@@ -13,7 +13,7 @@ app.use(bodyParser.urlencoded({ extended: true }));
 
 const celebRouter = require(__dirname + '/routes/celebRoutes');
 
-app.use(function(req,res, next) {
+app.use(function(req, res, next) {
   res.header('Access-Control-Allow-Origin', 'http://localhost:5000');
   res.header('Access-Control-Allow-Headers', 'Content-Type');
   res.header('Access-Control-Allow-Methods', 'GET, POST, DELETE, PUT');


### PR DESCRIPTION
In server/server.js, I removed the environment variable for the server port because client/entry.js only gives localhost:3000 as an option and if the user has set their environment port to something other than 3000, the routes don't work. 
